### PR TITLE
fix for .assert.jqueryElementNotPresent(selector)

### DIFF
--- a/js/assertions/jqueryElementNotPresent.js
+++ b/js/assertions/jqueryElementNotPresent.js
@@ -24,6 +24,9 @@ exports.assertion = function(selector, msg) {
     return !value;
   };
   this.value = function(result) {
+    if (!result) {
+      return false;
+    }
     return result.value;
   };
   this.command = function(callback) {


### PR DESCRIPTION
The whole point is that we want to confirm it is not found,
which is fine...

But I get:

```
TypeError: Cannot read property 'value' of null
    at value (/.../custom-maxgalbu/js/assertions/jqueryElementNotPresent.js:27:18)
```

Because we got back no object, so no chance to get a value from it.

This change handles that possibility gracefully, passing on `false` which
correctly evaluates.
