### PR TITLE
Remove nightwatch and coffeelint depandancy at installation time

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "These are some commands and assertion I use when I'm testing with nightwatch.js and selenium.",
   "main": "none",
   "scripts": {
-    "test": "./runTests.sh",
-    "preinstall": "npm install -g gulp coffeelint nightwatch"
+    "test": "./runTests.sh"
   },
   "repository": {
     "type": "git",
@@ -32,7 +31,9 @@
     "gulp-rename": "^1.2.0",
     "gulp-util": "^3.0.4",
     "mockserver-client": "^1.0.3",
-    "selenium-server": "2.45.0"
+    "selenium-server": "2.45.0",
+    "coffeelint": "latest",
+    "nightwatch": "latest"
   },
   "dependencies": {
     "easyimage": "^1.2.2"

--- a/runTests.sh
+++ b/runTests.sh
@@ -1,5 +1,18 @@
 #!/usr/bin/env bash
 
+if ! which coffeelint ; then
+	echo "Coffeelint not installed globally. This is necessary for running tests"
+	echo "npm install coffeelint -g"
+	echo "Please note that nightwatch is also necessary globally"
+	exit 1
+fi
+
+if ! which nightwatch ; then
+        echo "Nightwatch not installed globally. This is necessary for running tests"
+	echo "npm install nightwatch -g"
+        exit 1
+fi
+
 NIGHTWATCH_ENV=${NIGHTWATCH_ENV:-default}
 
 #Lint the coffee files


### PR DESCRIPTION
Proposed fix for #7 

This change push the required "coffeescript" and "nightwatch" dependancy into the runTests.sh script, since those two dependencies are required at test time, and not at use time.

This will ease the use of the npm package by anybody, and the package become more "standard", "clean".
